### PR TITLE
fix: Send objects with correct content-type in multipart requests

### DIFF
--- a/app/ui/src/app/core/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/core/providers/api-http-provider.service.ts
@@ -99,7 +99,16 @@ export class ApiHttpProviderService extends ApiHttpService {
     if (body) {
       for (const key in body) {
         if (body.hasOwnProperty(key)) {
-          multipartFormData.append(key, body[key]);
+          if (typeof body[key] === 'object') {
+            multipartFormData.append(key, new Blob(
+              [JSON.stringify(body[key])],
+              {
+                type: "application/json"
+              }
+            ));
+          } else {
+            multipartFormData.append(key, body[key]);
+          }
         }
       }
     }


### PR DESCRIPTION
As discussed on IRC - I haven't tested this out, but it should work hopefully.